### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/Damexi/6284ad12-fbcc-4840-9614-7e95100a5d3b/29498760-76c6-45f5-9b23-3c20c53bdc95/_apis/work/boardbadge/4d0a24fc-3514-4cf3-806e-1d3bb2641e62)](https://dev.azure.com/Damexi/6284ad12-fbcc-4840-9614-7e95100a5d3b/_boards/board/t/29498760-76c6-45f5-9b23-3c20c53bdc95/Microsoft.RequirementCategory)
 # Damexi


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/Damexi/6284ad12-fbcc-4840-9614-7e95100a5d3b/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.